### PR TITLE
Add classifiers and MANIFEST.in file to install package via pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,20 @@ setup(
     description=DESCRIPTION,
     url='https://github.com/mqcomplab/iSIM',
     packages=find_packages(),
+    include_package_data=True, 
     install_requires=[
         'numpy', 
         'matplotlib', 
         'pandas', 
-        'rdkit', 
+        'rdkit', #Not available on PyPI. User might need to install separately
         'scipy', 
         'seaborn', 
         'scikit-learn'
-    ]
+    ], 
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+    ],
+    zip_safe=False,
 )
 


### PR DESCRIPTION
I am working with AZ for REINVENT4. 
It will come in handy to make iSIM importable without user having to install the editable version of the code. 
The changes made here should make the package installable via: 

`pip install git+ssh://git@ssh.github.com/mqcomplab/iSIM.git`

Merging said changes now to ensure this is the case. Will not affect any source code, or any current user's code if they have installed the editable version already. 

In the future it would be nice if we could install via 

`pip install iSIM`

or something like that, but that requires some accounts I do not currently have. But can easily obtain. 
