### PR TITLE
Enh: speed-up for complementary similarity (C++)

### DIFF
--- a/iSIM/comp.cpp
+++ b/iSIM/comp.cpp
@@ -79,20 +79,20 @@ const int n_objects, const int k) { // data is column wise sum
 double calculate_isim(const Eigen::ArrayXf col_sum, 
                      const int n_objects, std::string n_ary){
     if (n_ary == "RR"){
-        double a = (col_sum*(col_sum-1.0)*0.5).sum();
+        double a = (col_sum.cast<double>()*(col_sum.cast<double>()-1.0)*0.5).sum();
         double p = n_objects*(n_objects-1.0)*col_sum.size()*0.5;
         return a/p;
     }
     else if(n_ary == "JT"){
-        double a = (col_sum*(col_sum-1.0)/2.0).sum();
+        double a = (col_sum.cast<double>()*(col_sum.cast<double>()-1.0)*0.5).sum();
         Eigen::ArrayXf off_coincidence = n_objects - col_sum;
-        double total_dis = (off_coincidence*col_sum).sum();
+        double total_dis = (off_coincidence.cast<double>()*col_sum.cast<double>()).sum();
         return a/(a+total_dis);
     }
     else if(n_ary == "SM"){
-        double a = (col_sum*(col_sum-1.0)/2.0).sum();
+        double a = (col_sum.cast<double>()*(col_sum.cast<double>()-1.0)*0.5).sum();
         Eigen::ArrayXf off_coincidence = n_objects - col_sum;
-        double d = (off_coincidence*(off_coincidence-1.0)/2.0).sum();
+        double d = (off_coincidence.cast<double>()*(off_coincidence.cast<double>()-1.0)/2.0).sum();
         double p = n_objects*(n_objects-1.0)*col_sum.size()/2.0;
         return (a+d)/p;
     }
@@ -135,7 +135,7 @@ Eigen::ArrayXd calculate_comp_sim(const  Eigen::ArrayXXf data, const std::string
     for (int i = 0; i < n_objects; i++){
         Eigen::ArrayXf current_row = data.row(i); // note: this needs to be declared here so that col_sum_current is also a vector of lenght n_features
         Eigen::ArrayXf col_sum_current = col_sum - current_row;
-        comp_sims(i) = calculate_isim(col_sum_current.cast<float>(), remaining_objects, n_ary);
+        comp_sims(i) = calculate_isim(col_sum_current, remaining_objects, n_ary);
     }
     return comp_sims;
 }


### PR DESCRIPTION
### What changed

The old implementation of `comp_sim` used a matrices to calculate the complementary similarity. Only element wise operations were needed. Therefore, I refactored the code so that it uses a parallelized for loop. Each iteration of the for loop is equivalent to one of the rows of the old implementation. 

Since I am using `calculate_isim`, I added casts to double so that the precision loss is comparable to the old and the python implementation of comp sim. 

### Performance
I ran a benchmarking test on randomly generated 100-10k fingerprints with varying lengths (166, 1024, 2048, and 4096). The average speed-up compared to the old C++ implementation ranged between 6.7x and 9x, whereas for python it ranged between 9.8x and 12.5x 

### Testing
I ran the unit tests locally. All test cases behaved as expected. The comp sim test passed and the sampling tests had a couple of fingerprints in a switched order, which is the same behavior of the old comp sim function. The selected indices were the same as the python indices in all tests.   