### PR TITLE
Perf: complementary similarity memory usage

### DIFF
--- a/iSIM/comp.py
+++ b/iSIM/comp.py
@@ -189,6 +189,7 @@ def calculate_medoid(data, n_ary = 'RR'):
 def calculate_outlier(data, n_ary = 'RR'):
     return np.argmax(calculate_comp_sim(data, n_ary = n_ary))
 
+
 def calculate_comp_sim(data, n_ary = 'RR'):
     """Calculate the complementary similarity for RR, JT, or SM
 
@@ -228,4 +229,10 @@ def calculate_comp_sim(data, n_ary = 'RR'):
     elif n_ary == 'SM':
         comp_sims = np.sum((a + (n_objects - comp_matrix) * (n_objects - comp_matrix - 1)/2), axis = 1)/(m * n_objects * (n_objects - 1)/2)
     
+    return comp_sims
+
+def calculate_comp_sim_new(data, n_ary = "RR"):
+    colsum = np.sum(data, axis = 0)
+    n_objects = len(data) - 1   
+    comp_sims = [calculate_isim(colsum - data[i], n_objects = n_objects, n_ary = n_ary) for i in range(len(data))]
     return comp_sims

--- a/iSIM/comp.py
+++ b/iSIM/comp.py
@@ -211,28 +211,8 @@ def calculate_comp_sim(data, n_ary = 'RR'):
         1D array with the complementary similarities of all the molecules in the set.
     """
     
-    n_objects = len(data) - 1
-    
-    c_total = np.sum(data, axis = 0)
-    m = len(c_total)
-    
-    comp_matrix = c_total - data
-    
-    a = comp_matrix * (comp_matrix - 1)/2
-    
-    if n_ary == 'RR':
-        comp_sims = np.sum(a, axis = 1)/(m * n_objects * (n_objects - 1)/2)
-    
-    elif n_ary == 'JT':
-        comp_sims = np.sum(a, axis = 1)/np.sum((a + comp_matrix * (n_objects - comp_matrix)), axis = 1)
-    
-    elif n_ary == 'SM':
-        comp_sims = np.sum((a + (n_objects - comp_matrix) * (n_objects - comp_matrix - 1)/2), axis = 1)/(m * n_objects * (n_objects - 1)/2)
-    
-    return comp_sims
-
-def calculate_comp_sim_new(data, n_ary = "RR"):
     colsum = np.sum(data, axis = 0)
     n_objects = len(data) - 1   
     comp_sims = [calculate_isim(colsum - data[i], n_objects = n_objects, n_ary = n_ary) for i in range(len(data))]
+    
     return comp_sims


### PR DESCRIPTION
This update provides a more memory efficient code for calculating the complementary similarity, especially for the longer fingerprints. We are not generating the matrices like `comp_matrix` and `a` from the previous implementation, but rather using a for loop to calculate the complementary similarity. The figure below shows the maximum memory usage for `calculate_comp_sim`. The fingerprints were randomly generated using `numpy`. I ran the calculations on my desktop (linux OS).

<img src="https://github.com/user-attachments/assets/4ce24e4d-0ad4-469c-97e6-32cc158a3890" width=80% height=80%>

Although this implementation for `calculate_comp_sim` does not use as much `numpy` features, the code performs faster for the longer fingerprints (1.5-2.0x speedup for fps of length 2048). It is, however, slower for fps of length 166. 

<img src="https://github.com/user-attachments/assets/076f46ac-9c86-4dcc-aa47-8b2777c76de8" width=80% height=80%>

Note: I ran into memory issues for the fps with length 4096. So I do not have the data for the old implementation. 