### PR TITLE
Test update

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -47,10 +47,4 @@ Warning: No fingerprints provided.
 [       OK ] testIsim.test_calculate_medoid (393 ms)
 ```
 
-## Known Issues
-
-* The selected indices for the sampling and diversity methods are ordered differently in C++.
- However, this is not an issue as the same indices are being selected, just in a different sequence.
-
-
 \- The iSIM Development Team

--- a/test/test_div.cpp
+++ b/test/test_div.cpp
@@ -8,8 +8,8 @@ TEST_F(testIsim, test_diversity){
     Eigen::ArrayXf idx_jt_python = read_fps("../python_results/diversity_JT_60percent_chembl214.csv");
     Eigen::ArrayXf idx_rr_eigen = Eigen::Map<Eigen::ArrayXi>(idx_rr.data(), idx_rr.size()).cast<float>();
     Eigen::ArrayXf idx_jt_eigen = Eigen::Map<Eigen::ArrayXi>(idx_jt.data(), idx_jt.size()).cast<float>();
-    compare_arrays(idx_rr_eigen, idx_rr_python, threshold);
-    compare_arrays(idx_jt_eigen, idx_jt_python, threshold);
+    compare_arrays(idx_rr_eigen, idx_rr_python, threshold, true);
+    compare_arrays(idx_jt_eigen, idx_jt_python, threshold, true);
 }
 
 TEST_F(testIsim, test_reverse_diversity){
@@ -19,7 +19,7 @@ TEST_F(testIsim, test_reverse_diversity){
     Eigen::ArrayXf idx_jt_python = read_fps("../python_results/reverse_diversity_JT_60percent_chembl214.csv");
     Eigen::ArrayXf idx_rr_eigen = Eigen::Map<Eigen::ArrayXi>(idx_rr.data(), idx_rr.size()).cast<float>();
     Eigen::ArrayXf idx_jt_eigen = Eigen::Map<Eigen::ArrayXi>(idx_jt.data(), idx_jt.size()).cast<float>();
-    compare_arrays(idx_rr_eigen, idx_rr_python, threshold);
-    compare_arrays(idx_jt_eigen, idx_jt_python, threshold);
+    compare_arrays(idx_rr_eigen, idx_rr_python, threshold, true);
+    compare_arrays(idx_jt_eigen, idx_jt_python, threshold, true);
 }
 

--- a/test/test_sampling.cpp
+++ b/test/test_sampling.cpp
@@ -5,63 +5,63 @@ TEST_F(testIsim, test_medoid_sampling_RR){
     std::vector<int> idx_rr = medoid_sampling(fps, "RR", 20.0);
     Eigen::ArrayXf idx_python_rr = read_fps("../python_results/medoid_sampling_RR_20percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_rr = Eigen::Map<Eigen::ArrayXi>(idx_rr.data(), idx_rr.size()).cast<float>();
-    compare_arrays(idx_python_rr, idx_eigen_rr, threshold);
+    compare_arrays(idx_python_rr, idx_eigen_rr, threshold, true);
 }
 
 TEST_F(testIsim, test_medoid_sampling_JT){
     std::vector<int> idx_jt = medoid_sampling(fps, "JT", 35.0);
     Eigen::ArrayXf idx_python_jt = read_fps("../python_results/medoid_sampling_JT_35percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_jt = Eigen::Map<Eigen::ArrayXi>(idx_jt.data(), idx_jt.size()).cast<float>();
-    compare_arrays(idx_python_jt, idx_eigen_jt, threshold);
+    compare_arrays(idx_python_jt, idx_eigen_jt, threshold, true);
 }
 
 TEST_F(testIsim, test_medoid_sampling_SM){
     std::vector<int> idx_sm = medoid_sampling(fps, "SM", 50.0);
     Eigen::ArrayXf idx_python_sm = read_fps("../python_results/medoid_sampling_SM_50percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_sm = Eigen::Map<Eigen::ArrayXi>(idx_sm.data(), idx_sm.size()).cast<float>();
-    compare_arrays(idx_python_sm, idx_eigen_sm, threshold);
+    compare_arrays(idx_python_sm, idx_eigen_sm, threshold,true);
 }
 
 TEST_F(testIsim, test_outlier_sampling_RR){
     std::vector<int> idx_rr = outlier_sampling(fps, "RR", 35.0);
     Eigen::ArrayXf idx_python_rr = read_fps("../python_results/outlier_sampling_RR_35percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_rr = Eigen::Map<Eigen::ArrayXi>(idx_rr.data(), idx_rr.size()).cast<float>();
-    compare_arrays(idx_python_rr, idx_eigen_rr, threshold);
+    compare_arrays(idx_python_rr, idx_eigen_rr, threshold,true);
 }
 
 TEST_F(testIsim, test_outlier_sampling_JT){
     std::vector<int> idx_jt = outlier_sampling(fps, "JT", 50.0);
     Eigen::ArrayXf idx_python_jt = read_fps("../python_results/outlier_sampling_JT_50percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_jt = Eigen::Map<Eigen::ArrayXi>(idx_jt.data(), idx_jt.size()).cast<float>();
-    compare_arrays(idx_python_jt, idx_eigen_jt, threshold);
+    compare_arrays(idx_python_jt, idx_eigen_jt, threshold,true);
 }
 
 TEST_F(testIsim, test_outlier_sampling_SM){
     std::vector<int> idx_sm = outlier_sampling(fps, "SM", 20.0);
     Eigen::ArrayXf idx_python_sm = read_fps("../python_results/outlier_sampling_SM_20percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_sm = Eigen::Map<Eigen::ArrayXi>(idx_sm.data(), idx_sm.size()).cast<float>();
-    compare_arrays(idx_python_sm, idx_eigen_sm, threshold);
+    compare_arrays(idx_python_sm, idx_eigen_sm, threshold,true);
 }
 
 TEST_F(testIsim, test_extremes_sampling_RR){
     std::vector<int> idx_rr = extremes_sampling(fps, "RR", 50.0);
     Eigen::ArrayXf idx_python_rr = read_fps("../python_results/extremes_sampling_RR_50percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_rr = Eigen::Map<Eigen::ArrayXi>(idx_rr.data(), idx_rr.size()).cast<float>();
-    compare_arrays(idx_python_rr, idx_eigen_rr, threshold);
+    compare_arrays(idx_python_rr, idx_eigen_rr, threshold,true);
 }
 
 TEST_F(testIsim, test_extremes_sampling_JT){
     std::vector<int> idx_jt = extremes_sampling(fps, "JT", 20.0);
     Eigen::ArrayXf idx_python_jt = read_fps("../python_results/extremes_sampling_JT_20percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_jt = Eigen::Map<Eigen::ArrayXi>(idx_jt.data(), idx_jt.size()).cast<float>();
-    compare_arrays(idx_python_jt, idx_eigen_jt, threshold);
+    compare_arrays(idx_python_jt, idx_eigen_jt, threshold, true);
 }
 
 TEST_F(testIsim, test_extremes_sampling_SM){
     std::vector<int> idx_sm = extremes_sampling(fps, "SM", 35.0);
     Eigen::ArrayXf idx_python_sm = read_fps("../python_results/extremes_sampling_SM_35percent_chembl214.csv");
     Eigen::ArrayXf idx_eigen_sm = Eigen::Map<Eigen::ArrayXi>(idx_sm.data(), idx_sm.size()).cast<float>();
-    compare_arrays(idx_python_sm, idx_eigen_sm, threshold);
+    compare_arrays(idx_python_sm, idx_eigen_sm, threshold, true);
 }
 
 // only using RR for stratified and quota sampling
@@ -70,12 +70,12 @@ TEST_F(testIsim, test_stratified_sampling_RR){
     std::vector<int> idx_strat = stratified_sampling(fps, "RR", 40.0, 15);
     Eigen::ArrayXf idx_python_strat = read_fps("../python_results/stratified_sampling_RR_40percent_15strata_chembl214.csv");
     Eigen::ArrayXf idx_eigen_strat = Eigen::Map<Eigen::ArrayXi>(idx_strat.data(), idx_strat.size()).cast<float>();
-    compare_arrays(idx_python_strat, idx_eigen_strat, threshold);
+    compare_arrays(idx_python_strat, idx_eigen_strat, threshold, true);
 }
 
 TEST_F(testIsim, test_quota_sampling_RR){
     std::vector<int> idx_quota = quota_sampling(fps, "RR", 40.0, 15);
     Eigen::ArrayXf idx_python_quota = read_fps("../python_results/quota_sampling_RR_40percent_15bins_chembl214.csv");
     Eigen::ArrayXf idx_eigen_quota = Eigen::Map<Eigen::ArrayXi>(idx_quota.data(), idx_quota.size()).cast<float>();
-    compare_arrays(idx_python_quota, idx_eigen_quota, threshold);
+    compare_arrays(idx_python_quota, idx_eigen_quota, threshold, true);
 }

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -69,15 +69,26 @@ Eigen::ArrayXXd read_compsim(std::string file_name) {
     }
 }
 
-void compare_arrays(Eigen::ArrayXf cpp_arr, Eigen::ArrayXf python_arr, double threshold){
+void compare_arrays(Eigen::ArrayXf cpp_arr, Eigen::ArrayXf python_arr, double threshold, bool sort){
+    // sort arg is there so that we can compare if the chosen indices are the same regardless of the order
+    // default is false
     ASSERT_EQ(cpp_arr.size(), python_arr.size());
-    bool equal = cpp_arr.isApprox(python_arr, threshold);
-    EXPECT_TRUE(equal);
-    if (!equal){
-        for (int i=0; i<cpp_arr.size(); i++){
-            if (std::abs(cpp_arr(i)-python_arr(i)) > threshold){
-                std::cout << "index: " << i << ", c++ result: " << cpp_arr(i);
-                std::cout << ", python result: " << python_arr(i) << std::endl;
+    if (sort){
+        std::sort(cpp_arr.begin(), cpp_arr.end());
+        std::sort(python_arr.begin(), python_arr.end());
+        bool equal = cpp_arr.isApprox(python_arr, threshold);
+        EXPECT_TRUE(equal);
+    }
+    else{
+        bool equal = cpp_arr.isApprox(python_arr, threshold);
+        EXPECT_TRUE(equal);
+    
+        if (!equal){
+            for (int i=0; i<cpp_arr.size(); i++){
+                if (std::abs(cpp_arr(i)-python_arr(i)) > threshold){
+                    std::cout << "index: " << i << ", c++ result: " << cpp_arr(i);
+                    std::cout << ", python result: " << python_arr(i) << std::endl;
+                }
             }
         }
     }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -19,4 +19,4 @@ class testIsim: public testing::Test{
         double threshold = 1e-6; // threshold for comparing floating point numbers
 };
 
-void compare_arrays(Eigen::ArrayXf cpp_arr, Eigen::ArrayXf python_arr, double threshold);
+void compare_arrays(Eigen::ArrayXf cpp_arr, Eigen::ArrayXf python_arr, double threshold, bool sort=false);


### PR DESCRIPTION
Added option to sort arrays before comparing them in `test_utils.cpp`. This way we can compare the selected indices regardless of the order they were chosen. Although this is a "softer" test than the one before, it solves the issue of precision loss when calculating the complementary similarity. 